### PR TITLE
AVR-DU enhancements

### DIFF
--- a/src/JTAG2.cpp
+++ b/src/JTAG2.cpp
@@ -447,10 +447,6 @@ void JTAG2::go() {
 
     bool is_bound = !chip_erased;
     switch (mem_type) {
-      case MTYPE_USERSIG:     // low-code-flash-region
-        /* BOOTROW is accepted as MTYPE_FLASH. */
-        /* According to ATDF, BOOTROW is a PRODSIG attribute. */
-        /* PRODSIG is traditionally implemented as r/o, so there is a conflict. */
       case MTYPE_PRODSIG:     // low-code-flash-region
         before_addr = ~0;
       case MTYPE_FLASH:       // low-code-flash-region
@@ -459,6 +455,10 @@ void JTAG2::go() {
         /* Continue to next case. */
       case MTYPE_FLASH_PAGE:  // high-code-flash-region (APPCODE)
       case MTYPE_BOOT_FLASH:  // high-code-flash-region (BOOTCODE)
+      case MTYPE_USERSIG:     // low-code-flash-region
+        /* BOOTROW is accepted as MTYPE_FLASH. */
+        /* According to ATDF, BOOTROW is a PRODSIG attribute. */
+        /* PRODSIG is traditionally implemented as r/o, so there is a conflict. */
       {
         if (!check_pagesize(flash_pagesize, length)) {
           /* Reject deta lengths that do not match page granularity. */

--- a/src/JTAG2.cpp
+++ b/src/JTAG2.cpp
@@ -288,6 +288,13 @@ void JTAG2::leave_progmode() {
   const uint8_t system_status = UPDI::CPU_mode<0xEF>();
   bool reset_ok = false;
   set_status(RSP_OK);
+  if (system_status & 0x08) {
+    // Please wait until NVMCTRL_STATUS completes before performing leave
+    if      (nvmctrl_version == '0') NVM::wait<false>();
+    else if (nvmctrl_version == '2') NVM_v2::wait<false>();
+    else if (nvmctrl_version == '4') NVM_v4::wait<false>();
+    else          /* ver 3 or 5 */   NVM_v3::wait<false>();
+  }
   switch (system_status) {
     // in program mode
     case 0x08:

--- a/src/JTAG2.cpp
+++ b/src/JTAG2.cpp
@@ -601,8 +601,6 @@ void JTAG2::go() {
         /* No need to proceed to enter_progmode() */
         break;
       }
-      /* In the case of AVRDUDE, there is no use below from here */
-      #ifdef ENABLE_ERASE_PAGE_COMMAND
       case XMEGA_ERASE_APP_PAGE:
       case XMEGA_ERASE_BOOT_PAGE:
       case XMEGA_ERASE_USERSIG:
@@ -641,7 +639,6 @@ void JTAG2::go() {
       case XMEGA_ERASE_EEPROM_PAGE:
         // Ignore page erase for eeprom, we use erase/write during the write step
         break;
-      #endif
       default:
         set_status(RSP_FAILED);
     }

--- a/src/sys.h
+++ b/src/sys.h
@@ -42,6 +42,11 @@
 // To erase an unlocked chip, use the NVMCTRL function to erase FLASH.
 #define ENABLE_FAST_ERASE
 
+// It will automatically reset as soon as the process is complete.
+// This is required to initialize the timer and allow continued operation.
+// There is no opportunity to see the exit status LED.
+#define ENABLE_CONTINUOUS_OPERATION
+
 // Auxiliary Macros
 #define CONCAT(A,B) A##B                // concatenate
 #define XCONCAT(A,B) CONCAT(A,B)        // expand and concatenate

--- a/src/sys.h
+++ b/src/sys.h
@@ -39,6 +39,9 @@
 // Returns pseudo signature when device is locked
 #define ENABLE_PSEUDO_SIGNATURE
 
+// To erase an unlocked chip, use the NVMCTRL function to erase FLASH.
+#define ENABLE_FAST_ERASE
+
 // Auxiliary Macros
 #define CONCAT(A,B) A##B                // concatenate
 #define XCONCAT(A,B) CONCAT(A,B)        // expand and concatenate


### PR DESCRIPTION
Support for larger USERROW than before.

In the AVR-DU series, USERROW is expanded to 512 bytes. This typically matches the granularity of his FLASH pages for the AVR-Dx series. Also, since the starting address is 0x1200, only one page is specified in the FLASH erase command.

There are two ways to write USERROW. Write using UPDI's special procedure, or use NVMCTRL's regular FLASH write. Both require 256 word access to be enabled.